### PR TITLE
Add Dependencies & devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,19 @@
     "eslint-plugin-react": "^5.0.1",
     "extract-text-webpack-plugin": "^1.0.1",
     "html-webpack-plugin": "^2.16.0",
-    "style-loader": "^0.13.1"
+    "style-loader": "^0.13.1",
+    "webpack": "^1.13.1",
+    "webpack-dev-middleware": "^1.6.1",
+    "webpack-hot-middleware": "^2.12.2",
+    "less": "^2.3.1",
+    "less-loader": "^2.2.3",
+    "file-loader": "^0.9.0",
+    "redbox-react": "^1.2.10",
+    "react-transform-catch-errors": "^1.0.2",
+    "react-transform-hmr": "^1.0.4"
   },
   "dependencies": {
+    "express": "^4.13.4",
     "history": "^2.1.1",
     "lodash": "^4.11.1",
     "parse": "1.6.14",


### PR DESCRIPTION
Dependencies:
- if express is not installed globally it is better to have it to be installed by npm

devDependencies: 
- file-loader for Webpack
- all packages already mentioned in pending pull request by @jiawenzhang
